### PR TITLE
Handle potential non-string elements in the path to an error

### DIFF
--- a/check_jsonschema.py
+++ b/check_jsonschema.py
@@ -123,7 +123,7 @@ def main():
             if filename in failures:
                 err = failures[filename]
                 path = (
-                    ".".join(x if "." not in x else f'"{x}"' for x in err.path)
+                    ".".join(str(x) if "." not in str(x) else f'"{str(x)}"' for x in err.path)
                     or "<root>"
                 )
                 print(f'  \033[0;33m{filename}::{path}: \033[0m{err.message}')


### PR DESCRIPTION
Stringifying Path Dequeue elements to prevent unexpected exception when trying to resolve invalid Json element path.

Related to reported issue: https://github.com/sirosen/check-jsonschema/issues/1