### PR TITLE
fallback when last-modified http header is missing and macos cache dir

### DIFF
--- a/check_jsonschema.py
+++ b/check_jsonschema.py
@@ -57,7 +57,7 @@ def cached_open(file_url, filename):
             # get both timestamps as epoch times
             local_mtime = os.path.getmtime(dest)
             remote_mtime = time.mktime(
-                time.strptime(conn.headers["last-modified"], "%a, %d %b %Y %H:%M:%S %Z")
+                time.strptime(conn.headers.get("last-modified", "Sun, 01 Jan 1970 00:00:01 GMT"), "%a, %d %b %Y %H:%M:%S %Z")
             )
             do_download = local_mtime < remote_mtime
         if do_download:

--- a/check_jsonschema.py
+++ b/check_jsonschema.py
@@ -20,9 +20,6 @@ sysname = platform.system()
 # that case
 if sysname == "Windows":
     CACHE_DIR = os.getenv("LOCALAPPDATA", os.getenv("APPDATA"))
-# macOS -> app support dir
-elif sysname == "Darwin":
-    CACHE_DIR = os.path.expanduser("~/Library/Application Support")
 # default for unknown platforms, namely linux behavior
 # use XDG env var and default to ~/.cache/
 else:


### PR DESCRIPTION
- [last-modified http header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Last-Modified) is not mandatory and when missing, the software should not fail
- treat macos as linux for caching files

and thank you @sirosen for check-jsonschema