### PR TITLE
macos cache directory

### DIFF
--- a/check_jsonschema.py
+++ b/check_jsonschema.py
@@ -22,7 +22,7 @@ if sysname == "Windows":
     CACHE_DIR = os.getenv("LOCALAPPDATA", os.getenv("APPDATA"))
 # macOS -> app support dir
 elif sysname == "Darwin":
-    CACHE_DIR = os.path.expanduser("~/Library/Application Support")
+    CACHE_DIR = os.path.expanduser("~/Library/Caches")
 # default for unknown platforms, namely linux behavior
 # use XDG env var and default to ~/.cache/
 else:


### PR DESCRIPTION
would like to propose to chance macos caching directory to make backup utilities (such as time machine) ignore these files by convention.

relates to https://github.com/sirosen/check-jsonschema/pull/5#issuecomment-868843403