### PR TITLE
fix: compute base_URI for RefResolver instance

### DIFF
--- a/src/check_jsonschema/loaders.py
+++ b/src/check_jsonschema/loaders.py
@@ -95,6 +95,9 @@ class SchemaLoader:
         validator_cls = jsonschema.validators.validator_for(schema)
         validator_cls.check_schema(schema)
         validator = validator_cls(schema, format_checker=format_checker)
+        validator = validator_cls(schema,
+                                  format_checker=format_checker,
+                                  resolver=ref_resolver)
         return validator
 
 


### PR DESCRIPTION
A PR to address #17 ...

Started as a draft, because I'm not overly thrilled with these changes.

## Pros
The changes to the `get_validator()` method seems to work well, but assumes a `_base_uri` attribute is defined.

## Cons
I made more changes to the `__init__` method than intended/hoped, but that was to enable a `_base_uri` attribute for both remote and local schema documents.  I felt that the `pathlib` and `urllib` did keep the code minimal.  In the `loaders.py` - there is only one instance of `os.path` - which I replaced with equivalent `pathlib` functionality.   I'm not sure if introducing these libraries is controversial.

I still think a case that is not addressed/won't-work-well is:
* a remote schema (https/http) that does not contain an `$id` attribute - will work.  However, the downloading/caching I *think* is handled by `jsonschema`, not `check-jsonschema`, for any `$ref` attributes.
* a remote schema **with** and `$id` - will effectively be ignored as the base URI.

### Questions/Uncertainties
A few use cases were mentioned about [relative $id attributes](https://json-schema.org/understanding-json-schema/structuring.html#id), but I'm not sure if it's worth addressing?

## References
Used the following reference to understand the intended structure of complex JSON schemas:

* https://json-schema.org/understanding-json-schema/structuring.html