### PR TITLE
Fix check-renovate not detecting any files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -52,8 +52,7 @@
   language: python
   files: >
     (?x)^(
-      \.(github|gitlab)/renovate.(json|json5)|
-      renovate.(json|json5)|
+      \.(github|gitlab)/renovate.json|
+      renovate.json|
       .renovaterc(|.json)
     )$
-  types: [yaml]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ These hooks check known files against schemas provided by other sources:
 
 - check-renovate:
     Validate RenovateBot config against the schema provided by Renovate (does
-    not support config in package.json)
+    not support config in package.json or JSON5)
 
 ## Example Usage
 


### PR DESCRIPTION
## Bug Report

The `types` config value for `check-renovate` is currently set to `yaml`, which is a bug because Renovate [only supports](https://docs.renovatebot.com/configuration-options/) JSON config files.

Furthermore, using `renovate.json5` with `check-jsonschema` doesn't actually work, because the `jsonschema` library doesn't support JSON5 syntax.

## Fix

`types` are supposed to be a [simplified version](https://pre-commit.com/#filtering-files-with-types) of writing regexes with `files`. Since `files` is necessary anyway I took out the redundant `types` and just updated the regex.

## Testing

I discovered this while trying to use the `check-renovate` hook when I realized that check is always marked as "Skipped". Tested locally with these fixes. ✅ 