### PR TITLE
Switch to pre-commit.ci ; Remove pre-commit from github actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,8 +18,6 @@ jobs:
           python-version: ${{ matrix.py }}
       - name: install requirements
         run: python -m pip install tox
-      - name: lint
-        run: python -m tox -e lint
       - name: test
         run: python -m tox -e py
       - name: twine-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 # dogfood
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.3.2
+  rev: 0.10.2
   hooks:
     - id: check-github-workflows
 - repo: https://github.com/pre-commit/pre-commit-hooks.git

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ PKG_VERSION=$(shell grep '^version' setup.cfg | cut -d '=' -f2 | tr -d ' ')
 
 .PHONY: lint test vendor-schemas release showvars
 lint:
-	tox -e lint
+	pre-commit run -a
 test:
 	tox
 vendor-schemas:

--- a/tox.ini
+++ b/tox.ini
@@ -24,11 +24,6 @@ deps = coverage
 skip_install = true
 commands = coverage report --skip-covered
 
-[testenv:lint]
-deps = pre-commit<3
-skip_install = true
-commands = pre-commit run --all-files
-
 [testenv:twine-check]
 skip_install = true
 deps = twine


### PR DESCRIPTION
pre-commit.ci will handle running our hooks.

As a result, it's no longer useful to have `tox -e lint` either.
Update `make lint` to run pre-commit directly.

---

This should trigger a run in pre-commit.ci . If it does not, I'll need to evaluate why.