### PR TITLE
Use `requests` to make HTTP requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Use `requests` to make HTTP requests, and retry request failures
+
 ## 0.10.2
 
 - Fix the `check-renovate` hook, which was skipping all files. Do not attempt

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
     ruamel.yaml==0.16.12
     jsonschema>=3,<5.0  # TODO: drop 3.x when py3.6 is EOL
     identify<2.0
+    requests<3.0
 package_dir=
     =src
 packages = find:
@@ -39,6 +40,7 @@ dev =
     pytest<7
     pytest-cov<3
     pytest-xdist<3
+    responses==0.17.0
 
 [isort]
 profile = black

--- a/src/check_jsonschema/cachedownloader.py
+++ b/src/check_jsonschema/cachedownloader.py
@@ -1,11 +1,17 @@
 import contextlib
+import io
 import os
 import platform
 import shutil
 import tempfile
 import time
 import typing as t
-import urllib.request
+
+import requests
+
+
+class FailedDownloadError(Exception):
+    pass
 
 
 class CacheDownloader:
@@ -51,15 +57,30 @@ class CacheDownloader:
 
         return cache_dir
 
-    def _lastmod_from_conn(self, conn) -> float:
+    def _get_request(self) -> requests.Response:
+        try:
+            # do manual retries, rather than using urllib3 retries, to make it trivially
+            # testable with 'responses'
+            r: t.Optional[requests.Response] = None
+            for _attempt in range(3):
+                r = requests.get(self._file_url, stream=True)
+                if r.ok:
+                    return r
+            raise FailedDownloadError(
+                f"got responses with status={r.status_code}, retries exhausted"
+            )
+        except requests.RequestException as e:
+            raise FailedDownloadError("encountered error during download") from e
+
+    def _lastmod_from_response(self, response: requests.Response) -> float:
         return time.mktime(
             time.strptime(
-                conn.headers.get("last-modified", self._LASTMOD_DEFAULT),
+                response.headers.get("last-modified", self._LASTMOD_DEFAULT),
                 self._LASTMOD_FMT,
             )
         )
 
-    def _cache_hit(self, cachefile, conn):
+    def _cache_hit(self, cachefile: str, response: requests.Response) -> bool:
         # no file? miss
         if not os.path.exists(cachefile):
             return False
@@ -67,42 +88,35 @@ class CacheDownloader:
         # compare mtime on any cached file against the remote last-modified time
         # it is considered a hit if the local file is at least as new as the remote file
         local_mtime = os.path.getmtime(cachefile)
-        remote_mtime = self._lastmod_from_conn(conn)
+        remote_mtime = self._lastmod_from_response(response)
         return local_mtime >= remote_mtime
 
-    @contextlib.contextmanager
-    def _urlopen(self):
-        with urllib.request.urlopen(self._file_url) as conn:
-            yield conn
-
-    def _write(self, conn, dest):
+    def _write(self, dest: str, response: requests.Response) -> None:
         # download to a temp file and then move to the dest
         # this makes the download safe if run in parallel (parallel runs
         # won't create a new empty file for writing and cause failures)
         fp = tempfile.NamedTemporaryFile(mode="wb", delete=False)
-        fp.write(conn.read())
+        fp.write(response.content)
         fp.close()
         shutil.copy(fp.name, dest)
         os.remove(fp.name)
 
-    def _download(self):
+    def _download(self) -> str:
         os.makedirs(self._cache_dir, exist_ok=True)
         dest = os.path.join(self._cache_dir, self._filename)
 
-        with self._urlopen() as conn:
-            # check to see if we have a file which matches the connection
-            # only download if we do not (cache miss, vs hit)
-            if not self._cache_hit(dest, conn):
-                self._write(conn, dest)
+        response = self._get_request()
+        # check to see if we have a file which matches the connection
+        # only download if we do not (cache miss, vs hit)
+        if not self._cache_hit(dest, response):
+            self._write(dest, response)
 
         return dest
 
     @contextlib.contextmanager
-    def open(self):
-        if not self._cache_dir or self._disable_cache:
-            with urllib.request.urlopen(self._file_url) as fp:
-                yield fp
+    def open(self) -> io.BytesIO:
+        if (not self._cache_dir) or self._disable_cache:
+            yield io.BytesIO(self._get_request().content)
         else:
-            cached_file = self._download()
-            with open(cached_file, "r") as fp:
+            with open(self._download(), "rb") as fp:
                 yield fp

--- a/src/check_jsonschema/checker.py
+++ b/src/check_jsonschema/checker.py
@@ -50,8 +50,8 @@ class SchemaChecker:
     def get_validator(self):
         try:
             return self._schema_loader.make_validator(self._format_opts)
-        except SchemaParseError:
-            self._fail("Error: schemafile could not be parsed as JSON")
+        except SchemaParseError as e:
+            self._fail("Error: schemafile could not be parsed as JSON", e)
         except jsonschema.SchemaError as e:
             self._fail(f"Error: schemafile was not valid: {e}\n", e)
         except NoSuchSchemaError as e:

--- a/src/check_jsonschema/loaders/schema.py
+++ b/src/check_jsonschema/loaders/schema.py
@@ -9,7 +9,7 @@ import jsonschema
 import ruamel.yaml
 
 from ..builtin_schemas import get_builtin_schema
-from ..cachedownloader import CacheDownloader
+from ..cachedownloader import CacheDownloader, FailedDownloadError
 from ..formats import FormatOptions, make_format_checker
 from ..utils import is_url_ish
 from .errors import SchemaParseError, UnsupportedUrlScheme
@@ -87,7 +87,7 @@ class HttpSchemaReader:
         try:
             with self.downloader.open() as fp:
                 return _json_load_schema(self.url, fp)
-        except urllib.error.URLError as err:
+        except FailedDownloadError as err:
             if self.failover_builtin_schema:
                 val = get_builtin_schema(self.failover_builtin_schema)
                 if val:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import pytest
+import responses
+
+
+@pytest.fixture(autouse=True)
+def mocked_responses():
+    responses.start()
+    yield
+    responses.stop()
+    responses.reset()

--- a/tests/test_cachedownloader.py
+++ b/tests/test_cachedownloader.py
@@ -3,28 +3,29 @@ import platform
 import time
 
 import pytest
+import requests
+import responses
 
-from check_jsonschema.cachedownloader import CacheDownloader
-
-
-class DummyConnHeaders:
-    def __init__(self):
-        self.lastmod = "Sun, 01 Jan 2000 00:00:01 GMT"
-
-    def get(self, name, default):
-        if name.lower() == "last-modified":
-            if self.lastmod:
-                return self.lastmod
-        return default
+from check_jsonschema.cachedownloader import CacheDownloader, FailedDownloadError
 
 
-class DummyConn:
-    def __init__(self):
-        self.headers = DummyConnHeaders()
+def add_default_response():
+    responses.add(
+        "GET",
+        "https://example.com/schema1.json",
+        headers={"Last-Modified": "Sun, 01 Jan 2000 00:00:01 GMT"},
+        json={},
+        match_querystring=False,
+    )
 
 
-def test_default_filename_from_uri():
-    cd = CacheDownloader("https://foo.example.com/schema1.json")
+@pytest.fixture
+def default_response():
+    add_default_response()
+
+
+def test_default_filename_from_uri(default_response):
+    cd = CacheDownloader("https://example.com/schema1.json")
     assert cd._filename == "schema1.json"
 
 
@@ -44,7 +45,9 @@ def test_default_filename_from_uri():
         ("Linux", {"XDG_CACHE_HOME": "xdg-cache"}, "xdg-cache"),
     ],
 )
-def test_default_cache_dir(monkeypatch, sysname, fakeenv, expect_value):
+def test_default_cache_dir(
+    monkeypatch, default_response, sysname, fakeenv, expect_value
+):
     for var in ["LOCALAPPDATA", "APPDATA", "XDG_CACHE_HOME"]:
         monkeypatch.delenv(var, raising=False)
     for k, v in fakeenv.items():
@@ -65,7 +68,7 @@ def test_default_cache_dir(monkeypatch, sysname, fakeenv, expect_value):
     monkeypatch.setattr(platform, "system", fakesystem)
     monkeypatch.setattr(os.path, "expanduser", fake_expanduser)
 
-    cd = CacheDownloader("https://example.com/foo-schema.json")
+    cd = CacheDownloader("https://example.com/schema1.json")
     assert cd._cache_dir == expect_value
 
     if sysname == "Darwin":
@@ -76,21 +79,30 @@ def test_default_cache_dir(monkeypatch, sysname, fakeenv, expect_value):
         assert expanduser_path is None
 
 
-def test_cache_hit_by_mtime(monkeypatch):
+def test_cache_hit_by_mtime(monkeypatch, default_response):
     monkeypatch.setattr(os.path, "exists", lambda x: True)
 
     # local mtime = NOW, cache hit
     monkeypatch.setattr(os.path, "getmtime", lambda x: time.time())
-    cd = CacheDownloader("https://foo.example.com/schema1.json")
-    assert cd._cache_hit("/tmp/schema1.json", DummyConn())
+    cd = CacheDownloader("https://example.com/schema1.json")
+    assert cd._cache_hit(
+        "/tmp/schema1.json",
+        requests.get("https://example.com/schema1.json", stream=True),
+    )
 
     # local mtime = 0, cache miss
     monkeypatch.setattr(os.path, "getmtime", lambda x: 0)
-    cd = CacheDownloader("https://foo.example.com/schema1.json")
-    assert cd._cache_hit("/tmp/schema1.json", DummyConn()) is False
+    cd = CacheDownloader("https://example.com/schema1.json")
+    assert (
+        cd._cache_hit(
+            "/tmp/schema1.json",
+            requests.get("https://example.com/schema1.json", stream=True),
+        )
+        is False
+    )
 
 
-def test_cachedownloader_cached_file(tmp_path, monkeypatch):
+def test_cachedownloader_cached_file(tmp_path, monkeypatch, default_response):
     # create a file
     f = tmp_path / "foo.json"
     f.write_text("{}")
@@ -101,4 +113,66 @@ def test_cachedownloader_cached_file(tmp_path, monkeypatch):
     monkeypatch.setattr(cd, "_download", lambda: str(f))
 
     with cd.open() as fp:
-        assert fp.read() == "{}"
+        assert fp.read() == b"{}"
+
+
+@pytest.mark.parametrize(
+    "mode", ["filename", "filename_otherdir", "cache_dir", "disable_cache"]
+)
+@pytest.mark.parametrize("failures", (0, 1, 10, requests.ConnectionError))
+def test_cachedownloader_e2e(tmp_path, mode, failures):
+    if isinstance(failures, int):
+        for _i in range(failures):
+            responses.add(
+                "GET",
+                "https://example.com/schema1.json",
+                status=500,
+                match_querystring=False,
+            )
+    else:
+        responses.add(
+            "GET",
+            "https://example.com/schema1.json",
+            body=failures(),
+            match_querystring=False,
+        )
+    add_default_response()
+    f = tmp_path / "schema1.json"
+    if mode == "filename":
+        cd = CacheDownloader(
+            "https://example.com/schema1.json", filename=str(f), cache_dir=str(tmp_path)
+        )
+    elif mode == "filename_otherdir":
+        otherdir = tmp_path / "otherdir"
+        cd = CacheDownloader(
+            "https://example.com/schema1.json", filename=str(f), cache_dir=str(otherdir)
+        )
+    elif mode == "cache_dir":
+        cd = CacheDownloader(
+            "https://example.com/schema1.json", cache_dir=str(tmp_path)
+        )
+    elif mode == "disable_cache":
+        cd = CacheDownloader("https://example.com/schema1.json", disable_cache=True)
+    else:
+        raise NotImplementedError
+
+    if isinstance(failures, int) and failures < 3:
+        with cd.open() as fp:
+            assert fp.read() == b"{}"
+        if mode == "filename":
+            assert f.exists()
+        elif mode == "filename_otherdir":
+            otherdir = f.exists()
+        elif mode == "cache_dir":
+            assert (tmp_path / "schema1.json").exists()
+        elif mode == "disable_cache":
+            assert not (tmp_path / "schema1.json").exists()
+            assert not f.exists()
+        else:
+            raise NotImplementedError
+    else:
+        with pytest.raises(FailedDownloadError):
+            with cd.open() as fp:
+                pass
+        assert not (tmp_path / "schema1.json").exists()
+        assert not f.exists()


### PR DESCRIPTION
This lets us use `responses` for testing as well.

Request retries are included in the behavior, but done manually rather than via urllib3 Retry configurations.

closes #34