### PR TITLE
Coerced azure pipelines bool values to strings

### DIFF
--- a/src/check_jsonschema/transforms/azure_pipelines.py
+++ b/src/check_jsonschema/transforms/azure_pipelines.py
@@ -45,6 +45,9 @@ def traverse_data(data: t.Any):
         return traverse_dict(data)
     if isinstance(data, list):
         return traverse_list(data)
+    # Coerce booleans to Azure's bool-like regex
+    if isinstance(data, bool):
+        return str(data).lower()
     return data
 
 


### PR DESCRIPTION
This handles cases where `True` does not validate as a boolean in the Azure pipelines schema. Booleans are converted to lowercase string equivalents